### PR TITLE
Use fractional bps to express bridge fee

### DIFF
--- a/smart-contracts/contracts/RelayPool.sol
+++ b/smart-contracts/contracts/RelayPool.sol
@@ -21,7 +21,7 @@ struct OriginSettings {
   uint256 maxDebt;
   uint256 outstandingDebt;
   address proxyBridge;
-  uint16 bridgeFee; // basis points
+  uint32 bridgeFee; // fractional basis points (1 = 0.0001 bps)
   uint32 coolDown; // in seconds
 }
 
@@ -31,7 +31,7 @@ struct OriginParam {
   address bridge;
   address proxyBridge;
   uint256 maxDebt;
-  uint16 bridgeFee; // basis points
+  uint32 bridgeFee; // fractional basis points (1 = 0.0001 bps)
   uint32 coolDown; // in seconds
 }
 
@@ -418,7 +418,8 @@ contract RelayPool is ERC4626, Ownable {
     // Mark as processed if not
     messages[chainId][bridge][message.nonce] = data;
 
-    uint256 feeAmount = (message.amount * origin.bridgeFee) / 10000;
+    // Calculate fee using fractional basis points (1 = 0.0001 bps)
+    uint256 feeAmount = (message.amount * origin.bridgeFee) / 100000000;
     pendingBridgeFees += feeAmount;
 
     // Check if origin settings are respected
@@ -509,8 +510,8 @@ contract RelayPool is ERC4626, Ownable {
     // and we should deposit these funds into the yield pool
     _depositAssetsInYieldPool(amount);
 
-    // The amount is the amount that was loaned + the fees
-    uint256 feeAmount = (amount * origin.bridgeFee) / 10000;
+    // Calculate fee using fractional basis points (1 = 0.0001 bps)
+    uint256 feeAmount = (amount * origin.bridgeFee) / 100000000;
     pendingBridgeFees -= feeAmount;
     // We need to account for it in a streaming fashion
     _addToStreamingAssets(feeAmount);

--- a/smart-contracts/test/RelayPool/fees.hardhat.ts
+++ b/smart-contracts/test/RelayPool/fees.hardhat.ts
@@ -46,14 +46,11 @@ describe('Fees', () => {
 
     await relayPool.addOrigin({
       bridge: relayBridgeOptimism,
-      bridgeFee: 5,
+      bridgeFee: 50, // 0.05 bps
       chainId: 10,
       coolDown: 0,
-      // (0.05%)
       curator: userAddress,
-
       maxDebt: ethers.parseEther('10'),
-
       proxyBridge: oPStackNativeBridgeProxy,
     })
 
@@ -71,7 +68,7 @@ describe('Fees', () => {
       10,
       relayBridgeOptimism
     )
-    const fees = (amount * bridgeFee) / 10000n
+    const fees = (amount * bridgeFee) / 100000000n // Using fractional basis points
     const recipientBalanceBefore = await myToken.balanceOf(recipientAddress) // Probably 0
     const outstandingDebtBefore = await relayPool.outstandingDebt() // Probably 0
     const totalAssetsBefore = await relayPool.totalAssets()


### PR DESCRIPTION
We update the fee calculation logic to use 100,000,000 as the denominator instead of 10,000. This means 1 unit = 0.0001 bps (0.000001%) - e.g. 100 = 0.01 bps (0.0001%)
