### PR TITLE
Backend: track historical events

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
-    "@relay-protocol/abis": "1.0.2",
+    "@relay-protocol/abis": "workspace:*",
     "@relay-protocol/addresses": "1.0.5",
     "hono": "4.6.20",
     "ponder": "0.10.23",

--- a/backend/ponder.config.ts
+++ b/backend/ponder.config.ts
@@ -3,7 +3,7 @@ import { ABIs } from '@relay-protocol/helpers'
 import { http } from 'viem'
 
 import {
-  RelayPool,
+  IRelayPoolHistorical,
   RelayBridge,
   RelayPoolFactory,
   RelayBridgeFactory,
@@ -301,7 +301,7 @@ export default createConfig({
     },
 
     RelayPool: {
-      abi: RelayPool as Abi,
+      abi: IRelayPoolHistorical as Abi,
       network: relayPoolNetworks,
     },
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -89,7 +89,14 @@ ponder.on('RelayBridge:BridgeInitiated', BridgeInitiated)
  * - Links bridge and proxy bridge contracts
  * - Sets initial debt limits
  */
-ponder.on('RelayPool:OriginAdded', OriginAdded)
+ponder.on(
+  'RelayPool:OriginAdded((address curator, uint32 chainId, address bridge, address proxyBridge, uint256 maxDebt, uint32 bridgeFee, uint32 coolDown) origin)',
+  OriginAdded
+)
+ponder.on(
+  'RelayPool:OriginAdded((address curator, uint32 chainId, address bridge, address proxyBridge, uint256 maxDebt, uint16 bridgeFee, uint32 coolDown) origin)',
+  OriginAdded
+)
 
 /**
  * Handles the disabling of an origin in a RelayPool
@@ -99,12 +106,26 @@ ponder.on('RelayPool:OriginDisabled', OriginDisabled)
 /**
  * Handles Hyperlane messages when they successfully reached the pool and a new loan is emitted
  */
-ponder.on('RelayPool:LoanEmitted', LoanEmitted)
+ponder.on(
+  'RelayPool:LoanEmitted(uint256 indexed nonce, address indexed recipient, address asset, uint256 amount, (uint32 chainId, address bridge, address curator, uint256 maxDebt, uint256 outstandingDebt, address proxyBridge, uint32 bridgeFee, uint32 coolDown) origin, uint256 fees)',
+  LoanEmitted
+)
+ponder.on(
+  'RelayPool:LoanEmitted(uint256 indexed nonce, address indexed recipient, address asset, uint256 amount, (uint32 chainId, address bridge, address curator, uint256 maxDebt, uint256 outstandingDebt, address proxyBridge, uint16 bridgeFee, uint32 coolDown) origin, uint256 fees)',
+  LoanEmitted
+)
 
 /**
  * Handles the change of the outstanding debt of a relay pool
  */
-ponder.on('RelayPool:OutstandingDebtChanged', OutstandingDebtChanged)
+ponder.on(
+  'RelayPool:OutstandingDebtChanged(uint256 oldDebt, uint256 newDebt, (uint32 chainId, address bridge, address curator, uint256 maxDebt, uint256 outstandingDebt, address proxyBridge, uint32 bridgeFee, uint32 coolDown) origin, uint256 oldOriginDebt, uint256 newOriginDebt)',
+  OutstandingDebtChanged
+)
+ponder.on(
+  'RelayPool:OutstandingDebtChanged(uint256 oldDebt, uint256 newDebt, (uint32 chainId, address bridge, address curator, uint256 maxDebt, uint256 outstandingDebt, address proxyBridge, uint16 bridgeFee, uint32 coolDown) origin, uint256 oldOriginDebt, uint256 newOriginDebt)',
+  OutstandingDebtChanged
+)
 
 /**
  * Handles proven withdrawals from the OP portal

--- a/smart-contracts/contracts/interfaces/IRelayPool.sol
+++ b/smart-contracts/contracts/interfaces/IRelayPool.sol
@@ -85,7 +85,7 @@ interface IRelayPool is IERC4626 {
     function WETH() external view returns (address);
     function FRACTIONAL_BPS_DENOMINATOR() external view returns (uint256);
     function outstandingDebt() external view returns (uint256);
-    function authorizedOrigins(uint32 chainId, address bridge) external view returns (OriginSettings memory);
+    function authorizedOrigins(uint32 chainId, address bridge) external view returns (uint32, address, address, uint256, uint256, address, uint32, uint32); // use explicit tuple for struct OriginSettings
     function messages(uint32 chainId, address bridge, uint256 nonce) external view returns (bytes memory);
     function yieldPool() external view returns (address);
     function tokenSwapAddress() external view returns (address);

--- a/smart-contracts/contracts/interfaces/IRelayPool.sol
+++ b/smart-contracts/contracts/interfaces/IRelayPool.sol
@@ -1,7 +1,119 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
-
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 interface IRelayPool is IERC4626 {
-  function WETH() external view returns (address);
-}
+    struct OriginSettings {
+        uint32 chainId;
+        address bridge;
+        address curator;
+        uint256 maxDebt;
+        uint256 outstandingDebt;
+        address proxyBridge;
+        uint32 bridgeFee; // fractional basis points
+        uint32 coolDown; // in seconds
+    }
+
+    struct OriginParam {
+        address curator;
+        uint32 chainId;
+        address bridge;
+        address proxyBridge;
+        uint256 maxDebt;
+        uint32 bridgeFee; // fractional basis points
+        uint32 coolDown; // in seconds
+    }
+
+    // Events
+    event LoanEmitted(
+        uint256 indexed nonce,
+        address indexed recipient,
+        ERC20 asset,
+        uint256 amount,
+        OriginSettings origin,
+        uint256 fees
+    );
+
+    event BridgeCompleted(
+        uint32 chainId,
+        address indexed bridge,
+        uint256 amount,
+        uint256 fees
+    );
+
+    event OutstandingDebtChanged(
+        uint256 oldDebt,
+        uint256 newDebt,
+        OriginSettings origin,
+        uint256 oldOriginDebt,
+        uint256 newOriginDebt
+    );
+
+    event AssetsDepositedIntoYieldPool(uint256 amount, address yieldPool);
+    event AssetsWithdrawnFromYieldPool(uint256 amount, address yieldPool);
+    event TokenSwapChanged(address prevAddress, address newAddress);
+    event YieldPoolChanged(address oldPool, address newPool);
+    event OriginDisabled(
+        uint32 chainId,
+        address bridge,
+        uint256 maxDebt,
+        uint256 outstandingDebt,
+        address proxyBridge
+    );
+
+    event OriginAdded(OriginParam origin);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event StreamingPeriodChanged(uint256 oldPeriod, uint256 newPeriod);
+
+    error FailedTransfer(address recipient, uint256 amount);
+    error InsufficientFunds(uint256 amount, uint256 balance);
+    error MessageAlreadyProcessed(uint32 chainId, address bridge, uint256 nonce);
+    error MessageTooRecent(uint32 chainId, address bridge, uint256 nonce, uint256 timestamp, uint32 coolDown);
+    error NotAWethPool();
+    error OwnableInvalidOwner(address owner);
+    error OwnableUnauthorizedAccount(address account);
+    error SafeERC20FailedOperation(address token);
+    error SharePriceTooHigh(uint256 actualPrice, uint256 maxPrice);
+    error SharePriceTooLow(uint256 actualPrice, uint256 minPrice);
+    error TooMuchDebtFromOrigin(uint32 chainId, address bridge, uint256 maxDebt, uint256 nonce, address recipient, uint256 amount);
+    error UnauthorizedCaller(address sender);
+    error UnauthorizedOrigin(uint32 chainId, address bridge);
+    error UnauthorizedSwap(address token);
+
+    // View functions
+    function HYPERLANE_MAILBOX() external view returns (address);
+    function WETH() external view returns (address);
+    function FRACTIONAL_BPS_DENOMINATOR() external view returns (uint256);
+    function outstandingDebt() external view returns (uint256);
+    function authorizedOrigins(uint32 chainId, address bridge) external view returns (OriginSettings memory);
+    function messages(uint32 chainId, address bridge, uint256 nonce) external view returns (bytes memory);
+    function yieldPool() external view returns (address);
+    function tokenSwapAddress() external view returns (address);
+    function pendingBridgeFees() external view returns (uint256);
+    function totalAssetsToStream() external view returns (uint256);
+    function lastAssetsCollectedAt() external view returns (uint256);
+    function endOfStream() external view returns (uint256);
+    function streamingPeriod() external view returns (uint256);
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function nonces(address owner) external view returns (uint256);
+    function owner() external view returns (address);
+    
+    // State changing functions
+    function handle(uint32 chainId,
+        bytes32 bridgeAddress,
+        bytes calldata data
+    ) external payable;
+    function claim(uint32 chainId, address bridge) external returns (uint256);
+    function disableOrigin(uint32 chainId, address bridge) external;
+    function updateStreamedAssets() external returns (uint256);
+    function setTokenSwap(address newTokenSwap) external;
+    function addOrigin(OriginParam calldata param) external;
+    function collectNonDepositedAssets() external;
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function processFailedHandler(uint32 chainId, address bridge, bytes calldata data) external;
+    function renounceOwnership() external;
+    function swapAndDeposit(address token, uint256 amount, uint24 uniswapWethPoolFeeToken, uint24 uniswapWethPoolFeeAsset, uint48 deadline, uint256 amountOutMinimum) external;
+    function transferOwnership(address newOwner) external;
+    function updateStreamingPeriod(uint256 newPeriod) external;
+    function updateYieldPool(address newPool, uint256 minSharePriceFromOldPool, uint256 maxSharePricePriceFromNewPool) external;
+} 

--- a/smart-contracts/contracts/interfaces/IRelayPoolHistorical.sol
+++ b/smart-contracts/contracts/interfaces/IRelayPoolHistorical.sol
@@ -1,0 +1,46 @@
+// The role of this interface is to preserve signature that has been used in the past
+// and is still used in the wild.
+// We keep it in the codebase to avoid breaking changes.
+import {IRelayPool} from "./IRelayPool.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+interface IRelayPoolHistorical is IRelayPool {
+
+  // bridgeFee was uint16 (uint32 since #373 / 1b061b0)
+  struct OriginSettingsDeprecated {
+    uint32 chainId;
+    address bridge;
+    address curator;
+    uint256 maxDebt;
+    uint256 outstandingDebt;
+    address proxyBridge;
+    uint16 bridgeFee; // basis points
+    uint32 coolDown; // in seconds
+  }
+
+  struct OriginParamDeprecated {
+    address curator;
+    uint32 chainId;
+    address bridge;
+    address proxyBridge;
+    uint256 maxDebt;
+    uint16 bridgeFee; // basis points
+    uint32 coolDown; // in seconds
+  }
+
+  event OriginAdded(OriginParamDeprecated origin);
+  event LoanEmitted(
+        uint256 indexed nonce,
+        address indexed recipient,
+        ERC20 asset,
+        uint256 amount,
+        OriginSettingsDeprecated origin,
+        uint256 fees
+    );
+  event OutstandingDebtChanged(
+        uint256 oldDebt,
+        uint256 newDebt,
+        OriginSettingsDeprecated origin,
+        uint256 oldOriginDebt,
+        uint256 newOriginDebt
+    );
+}

--- a/smart-contracts/contracts/interfaces/IRelayPoolHistorical.sol
+++ b/smart-contracts/contracts/interfaces/IRelayPoolHistorical.sol
@@ -1,6 +1,7 @@
-// The role of this interface is to preserve signature that has been used in the past
-// and is still used in the wild.
-// We keep it in the codebase to avoid breaking changes.
+// The role of this interface is to preserve signatures that have been used in the past
+// and may be in use in the wild.
+// We keep it in the codebase to allow tracking and indexing of deprecated events.
+
 import {IRelayPool} from "./IRelayPool.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 interface IRelayPoolHistorical is IRelayPool {

--- a/smart-contracts/test/RelayPool/interface.hardhat.ts
+++ b/smart-contracts/test/RelayPool/interface.hardhat.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { Interface, ZeroAddress } from 'ethers'
+
+const parseInterface = (iface: Interface, filter = 'function') => {
+  const parsed = new ethers.Interface(
+    Object.values(iface.fragments.filter(({ type }) => type === filter))
+  )
+  return parsed.format(true)
+}
+
+// find any missing entries
+const compareInterfaces = (
+  iface1: Interface,
+  iface2: Interface,
+  filter = 'function'
+) => {
+  const i1 = parseInterface(iface1, filter)
+  const i2 = parseInterface(iface2, filter)
+  const missing = i1.filter((entry) => !i2.includes(entry))
+  const remaining = i2.filter((entry) => !i1.includes(entry))
+
+  // same numbers of elements
+  console.log({
+    filter,
+    i1: i1.length,
+    i2: i2.length,
+    missing,
+    remaining,
+  })
+  expect(i1.length).to.equal(i2.length)
+
+  // elements are identical
+  expect(
+    missing.length + remaining.length,
+    `\n${missing.length + remaining.length} errors.
+---
+${missing.length ? `Missing in interface:\n${missing.join('\n')}` : ''}.
+---
+${remaining.length ? `Missing in contract:\n${remaining.join('\n')}` : ''}`
+  ).to.equal(0)
+}
+
+describe('RelayPool / interface', () => {
+  let relayPoolContract: Interface
+  let relayPoolInterface: Interface
+
+  before(async () => {
+    ;({ interface: relayPoolContract } = await ethers.getContractFactory(
+      'contracts/RelayPool.sol:RelayPool'
+    ))
+    ;({ interface: relayPoolInterface } = await ethers.getContractAt(
+      'contracts/interfaces/IRelayPool.sol:IRelayPool',
+      ZeroAddress
+    ))
+  })
+
+  it('includes all public functions', async () => {
+    compareInterfaces(relayPoolContract, relayPoolInterface)
+  })
+  it('includes all events', async () => {
+    compareInterfaces(relayPoolContract, relayPoolInterface, 'event')
+  })
+  it('includes all structs', async () => {
+    compareInterfaces(relayPoolContract, relayPoolInterface, 'struct')
+  })
+  it('includes all errors', async () => {
+    compareInterfaces(relayPoolContract, relayPoolInterface, 'error')
+  })
+})

--- a/smart-contracts/test/RelayPool/interface.hardhat.ts
+++ b/smart-contracts/test/RelayPool/interface.hardhat.ts
@@ -20,14 +20,9 @@ const compareInterfaces = (
   const missing = i1.filter((entry) => !i2.includes(entry))
   const remaining = i2.filter((entry) => !i1.includes(entry))
 
-  // same numbers of elements
-  console.log({
-    filter,
-    i1: i1.length,
-    i2: i2.length,
-    missing,
-    remaining,
-  })
+  // same numbers of  (non-null) elements
+  expect(i1.length).to.not.equal(0)
+  expect(i2.length).to.not.equal(0)
   expect(i1.length).to.equal(i2.length)
 
   // elements are identical
@@ -60,9 +55,6 @@ describe('RelayPool / interface', () => {
   })
   it('includes all events', async () => {
     compareInterfaces(relayPoolContract, relayPoolInterface, 'event')
-  })
-  it('includes all structs', async () => {
-    compareInterfaces(relayPoolContract, relayPoolInterface, 'struct')
   })
   it('includes all errors', async () => {
     compareInterfaces(relayPoolContract, relayPoolInterface, 'error')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.4.1":
+  version: 4.7.0
+  resolution: "@eslint-community/eslint-utils@npm:4.7.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10/43ed5d391526d9f5bbe452aef336389a473026fca92057cf97c576db11401ce9bcf8ef0bf72625bbaf6207ed8ba6bf0dcf4d7e809c24f08faa68a28533c491a7
+  languageName: node
+  linkType: hard
+
 "@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.12.1":
   version: 4.12.1
   resolution: "@eslint-community/regexpp@npm:4.12.1"
@@ -4706,7 +4717,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@relay-protocol/abis@npm:1.0.2, @relay-protocol/abis@workspace:packages/abis":
+"@relay-protocol/abis@workspace:*, @relay-protocol/abis@workspace:packages/abis":
   version: 0.0.0-use.local
   resolution: "@relay-protocol/abis@workspace:packages/abis"
   dependencies:
@@ -4738,7 +4749,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@relay-protocol/backend@workspace:backend"
   dependencies:
-    "@relay-protocol/abis": "npm:1.0.2"
+    "@relay-protocol/abis": "workspace:*"
     "@relay-protocol/addresses": "npm:1.0.5"
     "@types/node": "npm:22.13.0"
     "@typescript-eslint/eslint-plugin": "npm:8.23.0"
@@ -4805,9 +4816,9 @@ __metadata:
     eslint-config-prettier: "npm:10.1.2"
     eslint-plugin-evm-address-to-checksummed: "npm:0.0.6"
     eslint-plugin-json: "npm:4.0.1"
-    eslint-plugin-mocha: "npm:10.5.0"
+    eslint-plugin-mocha: "npm:11.0.0"
     eslint-plugin-prettier: "npm:5.2.6"
-    typescript-eslint: "npm:8.31.0"
+    typescript-eslint: "npm:8.31.1"
   languageName: unknown
   linkType: soft
 
@@ -6503,15 +6514,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.31.0"
+"@typescript-eslint/eslint-plugin@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.31.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.31.0"
-    "@typescript-eslint/type-utils": "npm:8.31.0"
-    "@typescript-eslint/utils": "npm:8.31.0"
-    "@typescript-eslint/visitor-keys": "npm:8.31.0"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/type-utils": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -6520,7 +6531,7 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/183ae3bdd56b7d87822a573c3312bca1e53c17956b618c2e84bf1e83f8015248251e85500370a80f2fec221e0dccf224e30a641edf138b42fe9be9362dd6476d
+  checksum: 10/be72838653e1f31da11b3f6515fa3b750f0c5c130bae315079920ee6b78e9c4d131790e2473ff7930e8d50dee45d623c9c90478fd78befb976c1736d369078e9
   languageName: node
   linkType: hard
 
@@ -6540,19 +6551,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/parser@npm:8.31.0"
+"@typescript-eslint/parser@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/parser@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.31.0"
-    "@typescript-eslint/types": "npm:8.31.0"
-    "@typescript-eslint/typescript-estree": "npm:8.31.0"
-    "@typescript-eslint/visitor-keys": "npm:8.31.0"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/468f9f9cc6e4685f88b8924bddd104ce940d48b63782a70682d46996c041676ba21d99b6561cac1dfbdcd9f57da9c80369283fec6c240c936b9d7948ac76d98e
+  checksum: 10/506c98b9c265faea4376f02e4d19b4722cd11c40f8e08e4c1b456eeb47bc59b70abaa604e633f1070eaf7c785cf7b39f30346f001d3e5257f8074f07a113eeff
   languageName: node
   linkType: hard
 
@@ -6566,13 +6577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.31.0"
+"@typescript-eslint/scope-manager@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.31.0"
-    "@typescript-eslint/visitor-keys": "npm:8.31.0"
-  checksum: 10/4ca30db2e6186415bcfa5bba24f55f3508c383d755cc3599c08087b04587276620b5d094439cd3df3e88bce25ad0f5bd2a4a7473ae59410c8ff9e72f87d7648e
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
+  checksum: 10/936aa866ba3564e9e41051e7ff811e08c9b01cbb7420ba2cd8fe8f0f466e5d59a8124b686744cfdecad211cdeefefaaf7d704aecddaa212f267d72e077dc7e44
   languageName: node
   linkType: hard
 
@@ -6591,18 +6602,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/type-utils@npm:8.31.0"
+"@typescript-eslint/type-utils@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/type-utils@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.31.0"
-    "@typescript-eslint/utils": "npm:8.31.0"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/b17aba3e9a7a2b4d7135345ce56a1dc4a3592335ba0ed956111abc9044bedb02a8382a2d3fc064f4a2f1ffe6023555db1930cf836bce447a1ac08c496212fabe
+  checksum: 10/d4c31837c1beb55f7037b0d94c2d73a855c7d921b3b07d68f6d7b476c475765f7707c7375f6190c1863e98e1bc98b8ce444806ab6a02759811eff1c710ab82a6
   languageName: node
   linkType: hard
 
@@ -6613,10 +6624,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/types@npm:8.31.0"
-  checksum: 10/937eca69241850ad94a5c93221191f2cbc448951f1672e913d106efe2bdd30d188c54d2502cbff5d4d9b3a95becf16387a20644239b1fee7458198cbdac4f923
+"@typescript-eslint/types@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/types@npm:8.31.1"
+  checksum: 10/18f534beb408398b8ed7f36fb9b9b8ff7e41fe6e5e8a7d0f6b16cc5ad0e55bb5920eeb28c71367e5cc7e0b9675ec961bc6a41bf58b4338c2264c0146322d83f5
   languageName: node
   linkType: hard
 
@@ -6638,12 +6649,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.31.0"
+"@typescript-eslint/typescript-estree@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.31.0"
-    "@typescript-eslint/visitor-keys": "npm:8.31.0"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -6652,7 +6663,7 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/e2155504e2231e69c909e0268b63979e3829d4e5b3845c4272b72de3cb855d225c26639d9dc23b2753464a9f6c5c8a31665640a90e10da20eb9462eff9115261
+  checksum: 10/0314ef90f277c76485182721662cf826c31c817acad04e9502b48352eb70bb109a6b7fad02a29d516413b0b1d1fc809c91016ccd5fcd6202ec1b282c6f848ff8
   languageName: node
   linkType: hard
 
@@ -6671,18 +6682,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/utils@npm:8.31.0"
+"@typescript-eslint/utils@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/utils@npm:8.31.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.31.0"
-    "@typescript-eslint/types": "npm:8.31.0"
-    "@typescript-eslint/typescript-estree": "npm:8.31.0"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/9e8fcef36bff920ba4eacc4289efc74a9aa65462849061d37d3014286948c8318b031a852555c7a7fe9cdf646458a2f82f7138171f7072ac595293979d5fd3a4
+  checksum: 10/c96253140f5a456b2dc4c9664d4527a88d8f537d9694e1f165665de20aea3936624cf93075f08f5cc2f5080e76021b9b2404a536d1b7980e38e3d1776c7c888c
   languageName: node
   linkType: hard
 
@@ -6696,13 +6707,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.31.0":
-  version: 8.31.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.31.0"
+"@typescript-eslint/visitor-keys@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.31.0"
+    "@typescript-eslint/types": "npm:8.31.1"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10/85417c4fb44735ace29201afa446e71bbdef074bf4543701c149eda22d51bf7b01c4da3ffc574dd9ef8b33ac4b5dea35a50326e413f223d2f5e73e4dc8e3c8ee
+  checksum: 10/14eb7e7ccb5fc29df979427b23729878d10deaa914d4eae1991c75c8ba88f3a2148889f03eeec09d1425a3b14fe37a10c2eafda60874c7020f620fd42d31fd5a
   languageName: node
   linkType: hard
 
@@ -9423,6 +9434,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-mocha@npm:11.0.0":
+  version: 11.0.0
+  resolution: "eslint-plugin-mocha@npm:11.0.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.1"
+    globals: "npm:^15.14.0"
+  checksum: 10/57e5f96bf258cb5d68027a8839cc4f5a00bb42d8d1fe7038440b5383b4e69c0e8436f0bd703d14428c1e34ac988ef25ee7b489f5269db6dcb0d7b83c6ae723ea
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:5.2.3":
   version: 5.2.3
   resolution: "eslint-plugin-prettier@npm:5.2.3"
@@ -10580,6 +10601,13 @@ __metadata:
   version: 14.0.0
   resolution: "globals@npm:14.0.0"
   checksum: 10/03939c8af95c6df5014b137cac83aa909090c3a3985caef06ee9a5a669790877af8698ab38007e4c0186873adc14c0b13764acc754b16a754c216cc56aa5f021
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.14.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: 10/7f561c87b2fd381b27fc2db7df8a4ea7a9bb378667b8a7193e61fd2ca3a876479174e2a303a74345fbea6e1242e16db48915c1fd3bf35adcf4060a795b425e18
   languageName: node
   linkType: hard
 
@@ -15999,17 +16027,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:8.31.0":
-  version: 8.31.0
-  resolution: "typescript-eslint@npm:8.31.0"
+"typescript-eslint@npm:8.31.1":
+  version: 8.31.1
+  resolution: "typescript-eslint@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.31.0"
-    "@typescript-eslint/parser": "npm:8.31.0"
-    "@typescript-eslint/utils": "npm:8.31.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.31.1"
+    "@typescript-eslint/parser": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/2984699104cacae4f553314c393b8c90bf31c9f327ebade848daa46eec93acf182ae54b87e2e319188eccf0a712d5f2e96bb82fc6aa4d2af24bc89c6919a424f
+  checksum: 10/becb67b353bf9e36a924f71dba7315bad1ae6c697dcbfa3510f2bacd7a95074ee5c56bb288c77f486a6b2345c92ca68201edb2145fafca6925842075224070d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds supports to index event in relay pools that have been removed from current versions of the contracts but may still be needed to track past actions

need to merge #395 first