### PR TITLE
sol lint fails on unused imports

### DIFF
--- a/smart-contracts/.solhint.json
+++ b/smart-contracts/.solhint.json
@@ -1,6 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
+    "no-unused-import": "error",
     "avoid-low-level-calls": "off",
     "ordering": "off",
     "func-visibility": [

--- a/smart-contracts/contracts/RelayPool.sol
+++ b/smart-contracts/contracts/RelayPool.sol
@@ -11,8 +11,6 @@ import {ITokenSwap} from "./interfaces/ITokenSwap.sol";
 import {TypeCasts} from "./utils/TypeCasts.sol";
 import {HyperlaneMessage} from "./Types.sol";
 import {IBridgeProxy} from "./interfaces/IBridgeProxy.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 
 struct OriginSettings {
   uint32 chainId;


### PR DESCRIPTION
just to keep contracts clean and free of dead deps