### PR TITLE
modify networks type to add required contract for checking chain status

### DIFF
--- a/packages/networks/src/networks/abstract.ts
+++ b/packages/networks/src/networks/abstract.ts
@@ -14,6 +14,7 @@ const config: ChildNetworkConfig = {
       parent: {
         nativeTokenVault: '0xbeD1EB542f9a5aA6419Ff3deb921A372681111f6',
         sharedDefaultBridge: '0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB',
+        diamondProxy: '0x2EDc71E9991A962c7FE172212d1aA9E50480fBb9',
       },
     },
   },

--- a/packages/networks/src/networks/ancient8.ts
+++ b/packages/networks/src/networks/ancient8.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     weth: '0x4200000000000000000000000000000000000006',
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0x639F2AECE398Aa76b07e59eF6abe2cFe32bacb68',
+        outputOracle: '0xB09DC08428C8b4EFB4ff9C0827386CDF34277996',
       },
     },
   },
@@ -22,7 +23,7 @@ const config: ChildNetworkConfig = {
   name: 'Ancient8',
   parentChainId: 1,
   rpc: ['https://rpc.ancient8.gg'],
-  stack: 'optimism',
+  stack: 'optimism-alt',
 }
 
 export default config

--- a/packages/networks/src/networks/base.ts
+++ b/packages/networks/src/networks/base.ts
@@ -25,6 +25,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x49048044D57e1C92A77f79988d21Fa8fAF74E97e',
+        gameFactory: '0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e',
       },
     },
   },

--- a/packages/networks/src/networks/baseSepolia.ts
+++ b/packages/networks/src/networks/baseSepolia.ts
@@ -24,6 +24,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x49f53e41452C74589E85cA1677426Ba426459e85',
+        gameFactory: '0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1',
       },
     },
   },

--- a/packages/networks/src/networks/bob.ts
+++ b/packages/networks/src/networks/bob.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     // TODO: add USDC
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0x8AdeE124447435fE03e3CD24dF3f4cAE32E65a3E',
+        outputOracle: '0xdDa53E23f8a32640b04D7256e651C1db98dB11C1',
       },
     },
   },

--- a/packages/networks/src/networks/cyber.ts
+++ b/packages/networks/src/networks/cyber.ts
@@ -12,6 +12,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x1d59bc9fcE6B8E2B1bf86D4777289FFd83D24C99',
+        gameFactory: '0xbF4676f21a7889E0Fd61BcDc9b98E60b01C1B36F',
       },
     },
   },

--- a/packages/networks/src/networks/hemi.ts
+++ b/packages/networks/src/networks/hemi.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     // TODO: add USDC
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0x39a0005415256B9863aFE2d55Edcf75ECc3A4D7e',
+        outputOracle: '0x6daF3a3497D8abdFE12915aDD9829f83A79C0d51',
       },
     },
   },
@@ -24,7 +25,7 @@ const config: ChildNetworkConfig = {
   rpc: process.env.RPC_43111
     ? [process.env.RPC_43111]
     : ['https://rpc.hemi.network/rpc'],
-  stack: 'optimism',
+  stack: 'optimism-alt',
 }
 
 export default config

--- a/packages/networks/src/networks/lisk.ts
+++ b/packages/networks/src/networks/lisk.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     weth: '0x4200000000000000000000000000000000000006',
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0x26dB93F8b8b4f7016240af62F7730979d353f9A7',
+        outputOracle: '0x113cB99283AF242Da0A0C54347667edF531Aa7d6',
       },
     },
   },
@@ -25,7 +26,7 @@ const config: ChildNetworkConfig = {
   rpc: process.env.RPC_1135
     ? [process.env.RPC_1135]
     : ['https://rpc.api.lisk.com'],
-  stack: 'optimism',
+  stack: 'optimism-alt',
 }
 
 export default config

--- a/packages/networks/src/networks/mint.ts
+++ b/packages/networks/src/networks/mint.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     weth: '0x4200000000000000000000000000000000000006',
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0x59625d1FE0Eeb8114a4d13c863978F39b3471781',
+        outputOracle: '0xB751A613f2Db932c6cdeF5048E6D2af05F9B98ED',
       },
     },
   },

--- a/packages/networks/src/networks/optimism.ts
+++ b/packages/networks/src/networks/optimism.ts
@@ -25,6 +25,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0xbEb5Fc579115071764c7423A4f12eDde41f106Ed',
+        gameFactory: '0xe5965Ab5962eDc7477C8520243A95517CD252fA9',
       },
     },
   },

--- a/packages/networks/src/networks/redstone.ts
+++ b/packages/networks/src/networks/redstone.ts
@@ -6,12 +6,13 @@ const config: ChildNetworkConfig = {
     weth: '0x4200000000000000000000000000000000000006',
   },
   bridges: {
-    optimism: {
+    optimismAlt: {
       child: {
         messagePasser: '0x4200000000000000000000000000000000000016',
       },
       parent: {
         portalProxy: '0xC7bCb0e8839a28A1cFadd1CF716de9016CdA51ae',
+        outputOracle: '0xa426A052f657AEEefc298b3B5c35a470e4739d69',
       },
     },
   },

--- a/packages/networks/src/networks/soneium.ts
+++ b/packages/networks/src/networks/soneium.ts
@@ -12,6 +12,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x88e529A6ccd302c948689Cd5156C83D4614FAE92',
+        gameFactory: '0x512a3d2c7a43bd9261d2b8e8c9c70d4bd4d503c0',
       },
     },
   },

--- a/packages/networks/src/networks/swell.ts
+++ b/packages/networks/src/networks/swell.ts
@@ -12,6 +12,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x758E0EE66102816F5C3Ec9ECc1188860fbb87812',
+        gameFactory: '0x87690676786cDc8cCA75A472e483AF7C8F2f0F57',
       },
     },
   },

--- a/packages/networks/src/networks/zero.ts
+++ b/packages/networks/src/networks/zero.ts
@@ -14,6 +14,7 @@ const config: ChildNetworkConfig = {
       parent: {
         nativeTokenVault: '0xbeD1EB542f9a5aA6419Ff3deb921A372681111f6',
         sharedDefaultBridge: '0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB',
+        diamondProxy: '0xdbD849acC6bA61F461CB8A41BBaeE2D673CA02d9',
       },
     },
   },

--- a/packages/networks/src/networks/zksync.ts
+++ b/packages/networks/src/networks/zksync.ts
@@ -18,6 +18,7 @@ const config: ChildNetworkConfig = {
       parent: {
         nativeTokenVault: '0xbeD1EB542f9a5aA6419Ff3deb921A372681111f6',
         sharedDefaultBridge: '0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB',
+        diamondProxy: '0x32400084c286cf3e17e7b677ea9583e60a000324',
       },
     },
   },

--- a/packages/networks/src/networks/zora.ts
+++ b/packages/networks/src/networks/zora.ts
@@ -12,6 +12,7 @@ const config: ChildNetworkConfig = {
       },
       parent: {
         portalProxy: '0x1a0ad011913A150f69f6A19DF447A0CfD9551054',
+        gameFactory: '0xB0F15106fa1e473Ddb39790f197275BC979Aa37e',
       },
     },
   },

--- a/packages/types/src/types/networks.ts
+++ b/packages/types/src/types/networks.ts
@@ -13,6 +13,16 @@ export interface ChildNetworkConfig extends NetworkConfig {
     optimism?: {
       parent: {
         portalProxy: string
+        gameFactory: string
+      }
+      child: {
+        messagePasser: string
+      }
+    }
+    optimismAlt?: {
+      parent: {
+        outputOracle: string
+        portalProxy: string
       }
       child: {
         messagePasser: string
@@ -45,6 +55,7 @@ export interface ChildNetworkConfig extends NetworkConfig {
       parent: {
         sharedDefaultBridge: string
         nativeTokenVault: string
+        diamondProxy: string
       }
       child: {
         l1Messenger: string


### PR DESCRIPTION
It appears the `optimism-alt` is loosely default rn and we may need a better way or even a better name