### PR TITLE
feat: adding a new status for better processing

### DIFF
--- a/backend/ponder.schema.ts
+++ b/backend/ponder.schema.ts
@@ -235,7 +235,7 @@ export const relayBridge = onchainTable(
  * - hyperlaneMessageId: ID of the fast Hyperlane message
  *
  * Bridge status:
- * - nativeBridgeStatus: INITIATED, PROVEN, FINALIZED
+ * - nativeBridgeStatus: INITIATED, HANDLED, PROVEN, FINALIZED
  * - nativeBridgeFinalizedTxHash: Transaction hash of finalization
  *
  * Loan tracking:

--- a/backend/src/handlers/OPPortal/WithdrawalProven.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalProven.ts
@@ -23,9 +23,6 @@ export default async function ({
       opProofTxHash: event.transaction.hash,
     })
     .where(
-      and(
-        eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash),
-        eq(bridgeTransaction.nativeBridgeStatus, 'INITIATED')
-      )
+      and(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
     )
 }

--- a/backend/src/handlers/RelayBridge/BridgeInitiated.ts
+++ b/backend/src/handlers/RelayBridge/BridgeInitiated.ts
@@ -114,7 +114,6 @@ export default async function ({
     destinationRecipient: recipient,
     expectedFinalizationTimestamp: event.block.timestamp + delay,
     hyperlaneMessageId,
-    nativeBridgeStatus: 'INITIATED',
     opWithdrawalHash,
     originSender: sender,
     originTimestamp: event.block.timestamp,
@@ -128,6 +127,7 @@ export default async function ({
       nonce,
       originBridgeAddress: event.log.address,
       originChainId: context.chain.id,
+      nativeBridgeStatus: 'INITIATED',
       ...values,
     })
     .onConflictDoUpdate(values)

--- a/backend/src/handlers/RelayPool/LoanEmitted.ts
+++ b/backend/src/handlers/RelayPool/LoanEmitted.ts
@@ -29,12 +29,15 @@ export default async function ({
     .insert(bridgeTransaction)
     .values({
       loanEmittedTxHash: event.transaction.hash,
-      nativeBridgeStatus: 'INITIATED',
+      nativeBridgeStatus: 'HANDLED',
       nonce,
       originBridgeAddress: bridge,
       originChainId: bridgeChainId,
     })
-    .onConflictDoUpdate({ loanEmittedTxHash: event.transaction.hash })
+    .onConflictDoUpdate({
+      loanEmittedTxHash: event.transaction.hash,
+      nativeBridgeStatus: 'HANDLED',
+    })
 
   // Update the RelayPool's totalBridgeFees field with the fee amount calculated
   // Retrieve the RelayPool record based on the contract address that emitted the event

--- a/claimer/main.ts
+++ b/claimer/main.ts
@@ -3,10 +3,12 @@ import { proveTransactions } from './src/prove-transactions'
 import { claimTransactions } from './src/claim-withdrawals'
 import { finalizeWithdrawals } from './src/finalize-withdrawals'
 import { checkL2Chains } from './src/check-l2-status'
+import { checkPendingBridges } from './src/check-pending-bridges'
 import { logger } from './src/logger'
 
 const run = async () => {
   const { vaultService } = await start()
+  await checkPendingBridges({ vaultService })
   await proveTransactions({ vaultService })
   await finalizeWithdrawals({ vaultService })
   await claimTransactions({ vaultService })

--- a/claimer/src/finalize-withdrawals.ts
+++ b/claimer/src/finalize-withdrawals.ts
@@ -10,7 +10,7 @@ const GET_ALL_TRANSACTIONS_TO_FINALIZE = gql`
     bridgeTransactions(
       where: {
         expectedFinalizationTimestamp_lt: $expectedFinalizationTimestamp
-        nativeBridgeStatus_in: ["FINALIZED", "WITHDRAWN"]
+        nativeBridgeStatus_in: ["HANDLED", "INITIATED"]
       }
     ) {
       items {

--- a/claimer/src/finalize-withdrawals.ts
+++ b/claimer/src/finalize-withdrawals.ts
@@ -10,7 +10,7 @@ const GET_ALL_TRANSACTIONS_TO_FINALIZE = gql`
     bridgeTransactions(
       where: {
         expectedFinalizationTimestamp_lt: $expectedFinalizationTimestamp
-        nativeBridgeStatus_in: ["HANDLED", "INITIATED"]
+        nativeBridgeStatus_in: ["HANDLED", "PROVEN"]
       }
     ) {
       items {

--- a/claimer/src/finalize-withdrawals.ts
+++ b/claimer/src/finalize-withdrawals.ts
@@ -10,7 +10,7 @@ const GET_ALL_TRANSACTIONS_TO_FINALIZE = gql`
     bridgeTransactions(
       where: {
         expectedFinalizationTimestamp_lt: $expectedFinalizationTimestamp
-        nativeBridgeStatus_not: "FINALIZED"
+        nativeBridgeStatus_in: ["FINALIZED", "WITHDRAWN"]
       }
     ) {
       items {

--- a/claimer/src/prove-transactions.ts
+++ b/claimer/src/prove-transactions.ts
@@ -13,7 +13,7 @@ const GET_ALL_TRANSACTIONS_TO_PROVE = gql`
   ) {
     bridgeTransactions(
       where: {
-        nativeBridgeStatus: $nativeBridgeStatus
+        nativeBridgeStatus_in: $nativeBridgeStatus
         originChainId_in: $originChainIds
         originTimestamp_lt: $originTimestamp
       }
@@ -45,7 +45,7 @@ export const proveTransactions = async ({
   const { bridgeTransactions } = await vaultService.query(
     GET_ALL_TRANSACTIONS_TO_PROVE,
     {
-      nativeBridgeStatus: 'INITIATED',
+      nativeBridgeStatus: 'HANDLED',
       originChainIds: OpChains,
       originTimestamp: Math.floor(new Date().getTime() / 1000) - 60 * 30,
     }

--- a/claimer/src/prove-transactions.ts
+++ b/claimer/src/prove-transactions.ts
@@ -13,7 +13,7 @@ const GET_ALL_TRANSACTIONS_TO_PROVE = gql`
   ) {
     bridgeTransactions(
       where: {
-        nativeBridgeStatus_in: $nativeBridgeStatus
+        nativeBridgeStatus: $nativeBridgeStatus
         originChainId_in: $originChainIds
         originTimestamp_lt: $originTimestamp
       }


### PR DESCRIPTION
This new status should let us distinguish cases where the bridge has been `INITIATED` from the ones where the funds have been dispersed on the vault (`HANDLED`). 
We are now proving or finalizing calls that are `HANDLED` only so we should reduce the likeliness of a a "native" bridge resolving before an hyperlane message (we would only try to prove tx that have been handled)