### PR TITLE
adding a check for pending transactions that need to be handled

### DIFF
--- a/claimer/src/check-pending-bridges.ts
+++ b/claimer/src/check-pending-bridges.ts
@@ -1,0 +1,38 @@
+import { gql } from 'graphql-request'
+import { logger } from './logger'
+
+const GET_DELAYED_BRIDGE_TRANSACTIONS = gql`
+  query GetDelayedBridgeTransactions($originTimestamp: BigInt!) {
+    bridgeTransactions(
+      where: {
+        originTimestamp_lt: $originTimestamp
+        nativeBridgeStatus_in: ["INITIATED"]
+      }
+    ) {
+      items {
+        destinationPoolAddress
+        destinationPoolChainId
+
+        originChainId
+        originBridgeAddress
+
+        originTxHash
+        originTimestamp
+      }
+    }
+  }
+`
+
+export const checkPendingBridges = async ({ vaultService }) => {
+  const { bridgeTransactions } = await vaultService.query(
+    GET_DELAYED_BRIDGE_TRANSACTIONS,
+    {
+      originTimestamp: Math.floor(Date.now() / 1000) - 60 * 60 * 24, // 24 hours ago
+    }
+  )
+  for (const tx of bridgeTransactions.items) {
+    logger.warn('Delayed transaction found', {
+      ...tx,
+    })
+  }
+}


### PR DESCRIPTION
We should create an alarm in datadog for this in order to detect any transaction that was not quickly processed on the pool.