### PR TITLE
cleaner log parsing

### DIFF
--- a/backend/bin/log-format.sh
+++ b/backend/bin/log-format.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
-# This script reads input from pipe and update json "service" field with a prefix
-LOG_PREFIX="vaults-backend-$1-"
+# This script parse (ponder) json logs from pipe and update the "service" field
+LOG_PREFIX=${SERVICE_NAME:-vaults-backend}
 
 while IFS=$'\n' read -r line; do
-    # add prefix to service field
-    service="$LOG_PREFIX$(echo $line | jq -r '.service')"
-    echo $line | jq -r --arg a "$service" '.service = ($a) | tostring' 
+    
+    # If not valid JSON, output as is
+    if ! echo "$line" | jq empty 2>/dev/null; then
+        echo "$line"
+        continue
+    fi
+    
+    # if log already has a 'dd' field, output as is
+    if $(echo $line | jq 'has("dd")'); then
+        echo $line
+        continue    
+    fi
+
+    # if no 'dd' field is present, replace ponder 'service' field
+    if $(echo $line | jq 'has("service")'); then
+        service="$LOG_PREFIX"
+        internal_service="$(echo $line | jq -r '.service')"
+        echo $line | jq -r --arg a "$service" --arg b "$internal_service" '.service = ($a) | .internal_service = ($b) | tostring' 
+    fi
 done

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "ponder dev",
-    "start": "ponder start --log-format json --schema $IMAGE_TAG",
-    "start-http-only": "ponder serve --log-format json --schema $IMAGE_TAG | sh $(pwd)/bin/log-format.sh server",
+    "start": "ponder start --log-format json --schema $IMAGE_TAG | sh $(pwd)/bin/log-format.sh",
+    "start-http-only": "ponder serve --log-level info --log-format json --schema $IMAGE_TAG | sh $(pwd)/bin/log-format.sh",
     "db": "ponder db",
     "codegen": "ponder codegen",
     "serve": "ponder serve",


### PR DESCRIPTION
use `SERVICE_NAME` env when parsing json logs to be consistent with deployment process