### PR TITLE
fix(backend): not deleting disabled origins

### DIFF
--- a/backend/src/handlers/RelayPool/OriginDisabled.ts
+++ b/backend/src/handlers/RelayPool/OriginDisabled.ts
@@ -21,10 +21,12 @@ export default async function ({
     return
   }
 
-  await context.db.delete(poolOrigin, {
-    chainId: context.chain.id,
-    originBridge: event.args.bridge as `0x${string}`,
-    originChainId: event.args.chainId,
-    pool: poolAddress as `0x${string}`,
-  })
+  await context.db
+    .update(poolOrigin, {
+      chainId: context.chain.id,
+      originBridge: event.args.bridge as `0x${string}`,
+      originChainId: event.args.chainId,
+      pool: poolAddress as `0x${string}`,
+    })
+    .set({ maxDebt: 0 })
 }


### PR DESCRIPTION
We should not delete origins when they are disabled since there could still be pending bridges that resolve (and events that are triggered!)