### PR TITLE
not requiring the state to be PROVEN

### DIFF
--- a/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
@@ -17,9 +17,6 @@ export default async function ({
       nativeBridgeStatus: 'FINALIZED',
     })
     .where(
-      and(
-        eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash),
-        eq(bridgeTransaction.nativeBridgeStatus, 'PROVEN')
-      )
+      and(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
     )
 }

--- a/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
@@ -16,7 +16,5 @@ export default async function ({
       nativeBridgeFinalizedTxHash: event.transaction.hash,
       nativeBridgeStatus: 'FINALIZED',
     })
-    .where(
-      and(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
-    )
+    .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
 }


### PR DESCRIPTION
This will make sure the `Lisk` tx is marked as FINALIZED.
We now have a strict order:
- `INITIATED`
- `HANDLED`
- `PROVEN` (we won't trigger proofs for tx that are not `HANDLED`)
- `FINALIZED` (by definition this must happen after a tx has been `PROVEN`)
