### PR TITLE
client: support only esm exports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,15 +2,14 @@
   "name": "@relay-vaults/client",
   "description": "Client library for interacting with the Relay Protocol API",
   "version": "0.1.5",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "type": "module",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "default": "./dist/index.js"
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
@@ -18,8 +17,8 @@
     "src"
   ],
   "scripts": {
-    "build": "yarn generate-types && tsup src/index.ts --dts --format esm,cjs",
-    "dev": "yarn generate-types && tsup src/index.ts --watch --dts --format esm,cjs",
+    "build": "yarn generate-types && tsup src/index.ts --dts --format esm",
+    "dev": "yarn generate-types && tsup src/index.ts --watch --dts --format esm",
     "clean": "rm -rf dist src/generated",
     "lint:fix": "yarn lint --fix",
     "lint": "eslint",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@relay-vaults/tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "moduleResolution": "bundler",
+    "module": "ESNext"
   },
   "exclude": ["dist", "bin"]
 }


### PR DESCRIPTION
we remove support for cjs exports as `graphql-request` is an ESM only module, which leads to error like 

```
// Error [ERR_REQUIRE_ESM]: require() of ES Module graphql-request from CommonJS not supported
```
      