### PR TITLE
client: use vite to build ems/cjs 

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@relay-vaults/client",
   "description": "Client library for interacting with the Relay Protocol API",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,8 +18,8 @@
     "src"
   ],
   "scripts": {
-    "build": "yarn generate-types && tsup src/index.ts --dts --format esm,cjs",
-    "dev": "yarn generate-types && tsup src/index.ts --watch --dts --format esm,cjs",
+    "build": "yarn generate-types && vite build && tsc -p tsconfig.build.json",
+    "dev": "yarn generate-types && vite build --watch",
     "clean": "rm -rf dist src/generated",
     "lint:fix": "yarn lint --fix",
     "lint": "eslint",
@@ -42,6 +42,7 @@
     "@types/node": "22.15.32",
     "eslint": "9.28.0",
     "tsup": "8.5.0",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vite": "5.4.14"
   }
 }

--- a/packages/client/scripts/test.js
+++ b/packages/client/scripts/test.js
@@ -1,8 +1,0 @@
-// This is what would cause the error in a real CommonJS environment
-const { RelayClient } = require('../dist/index.js')
-
-console.log('Successfully required RelayClient:', typeof RelayClient)
-
-// Try to instantiate the client
-const client = new RelayClient('http://localhost:42069/graphql')
-console.log('Successfully created client instance')

--- a/packages/client/scripts/test.js
+++ b/packages/client/scripts/test.js
@@ -1,0 +1,8 @@
+// This is what would cause the error in a real CommonJS environment
+const { RelayClient } = require('../dist/index.js')
+
+console.log('Successfully required RelayClient:', typeof RelayClient)
+
+// Try to instantiate the client
+const client = new RelayClient('http://localhost:42069/graphql')
+console.log('Successfully created client instance')

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+} 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      fileName: (format: string) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      formats: ['es', 'cjs'],
+      name: 'RelayClient',
+    },
+    rollupOptions: {
+      // Bundle the dependencies to avoid ES module issues
+      external: [],
+      output: {
+        // Remove globals since we're bundling everything
+      },
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4892,6 +4892,7 @@ __metadata:
     graphql-tag: "npm:2.12.6"
     tsup: "npm:8.5.0"
     typescript: "npm:5.8.3"
+    vite: "npm:5.4.14"
   languageName: unknown
   linkType: soft
 
@@ -17294,7 +17295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
+"vite@npm:5.4.14, vite@npm:^5.0.0":
   version: 5.4.14
   resolution: "vite@npm:5.4.14"
   dependencies:


### PR DESCRIPTION
will bundle deps and avoid `ERR_REQUIRE_ESM` in cjs as `graphql-request` is esm only