### PR TITLE
pass Arbitrum gas params on L1>L2 proxy bridge deposit

### DIFF
--- a/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
+++ b/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
@@ -75,7 +75,7 @@ contract ArbitrumOrbitNativeDepositBridgeProxy is BridgeProxy {
         amount, // token amount
         gasLimit, // Max gas deducted from user's L2 balance to cover L2 execution
         maxFeePerGas, // Gas price bid for L2 execution
-        abi.encode(maxSubmissionCost, moreData) // Extra data,
+        abi.encode(maxSubmissionCost, moreData)
       );
     }
   }

--- a/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
+++ b/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
@@ -37,8 +37,8 @@ contract ArbitrumOrbitNativeDepositBridgeProxy is BridgeProxy {
     bytes calldata gasParams,
     bytes calldata extraData
   ) external payable override {
-    (uint256 maxFeePerGas, uint256 gasLimit, uint256 maxSubmissionCost) = abi
-      .decode(gasParams, (uint256, uint256, uint256));
+    (uint256 maxFeePerGas, uint256 gasLimit, uint256 maxSubmissionCost, bytes memory moreData) = abi
+      .decode(extraData, (uint256, uint256, uint256));
 
     if (l1Currency == address(0)) {
       // simple deposit wont work as it deposits to an alias by default
@@ -53,7 +53,7 @@ contract ArbitrumOrbitNativeDepositBridgeProxy is BridgeProxy {
         address(this), // callValueRefundAddress (receives msg.value on l2)
         gasLimit, // gasLimit
         maxFeePerGas, // maxFeePerGas
-        extraData // data
+        moreData // data
       );
     } else {
       address l2token = ROUTER.calculateL2TokenAddress(l1Currency);
@@ -75,7 +75,7 @@ contract ArbitrumOrbitNativeDepositBridgeProxy is BridgeProxy {
         amount, // token amount
         gasLimit, // Max gas deducted from user's L2 balance to cover L2 execution
         maxFeePerGas, // Gas price bid for L2 execution
-        abi.encode(maxSubmissionCost, extraData) // Extra data,
+        abi.encode(maxSubmissionCost, moreData) // Extra data,
       );
     }
   }

--- a/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
+++ b/smart-contracts/contracts/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.sol
@@ -38,7 +38,7 @@ contract ArbitrumOrbitNativeDepositBridgeProxy is BridgeProxy {
     bytes calldata extraData
   ) external payable override {
     (uint256 maxFeePerGas, uint256 gasLimit, uint256 maxSubmissionCost, bytes memory moreData) = abi
-      .decode(extraData, (uint256, uint256, uint256));
+      .decode(extraData, (uint256, uint256, uint256, bytes));
 
     if (l1Currency == address(0)) {
       // simple deposit wont work as it deposits to an alias by default

--- a/smart-contracts/test/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.ethereum.ts
+++ b/smart-contracts/test/BridgeProxy/deposit/ArbitrumOrbitNativeDepositBridgeProxy.ethereum.ts
@@ -134,7 +134,7 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
     bridge = result.bridge
   })
 
-  describe.only('sending ERC20', () => {
+  describe('sending ERC20', () => {
     let balanceBefore: bigint
     const amount = parseUnits('0.1', 18)
     let receipt: TransactionReceipt | null
@@ -173,8 +173,8 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
 
       const abiCoder = new AbiCoder()
       const encodedGasEstimate = abiCoder.encode(
-        ['uint', 'uint', 'uint'],
-        [maxFeePerGas, gasLimit, maxSubmissionCost]
+        ['uint', 'uint', 'uint', 'bytes'],
+        [maxFeePerGas, gasLimit, maxSubmissionCost, '0x']
       )
       // send tx
       const gatewayRouter = await ethers.getContractAt(
@@ -188,8 +188,8 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
         udtArbAddress, // L2 token
         UDT_ETHEREUM, // l1 token
         amount,
-        encodedGasEstimate, // empty data
-        '0x', // empty extraData
+        '0x', // empty hyperlane gas data
+        encodedGasEstimate, // extraData
         {
           value: deposit,
         }
@@ -258,11 +258,12 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
 
       const abiCoder = new AbiCoder()
       const encodedGasEstimate = abiCoder.encode(
-        ['uint', 'uint', 'uint'],
+        ['uint', 'uint', 'uint', 'bytes'],
         [
           gasEstimate.maxFeePerGas,
           gasEstimate.gasLimit,
           gasEstimate.maxSubmissionCost,
+          '0x',
         ]
       )
 
@@ -270,8 +271,8 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
         ethers.ZeroAddress, // native token
         ethers.ZeroAddress, // l1 native token
         amount,
-        encodedGasEstimate, // empty data
-        '0x', // empty extraData
+        '0x', // empty hyperlane gas data
+        encodedGasEstimate, // use extraData
       ]
 
       // Send message to the bridge
@@ -299,7 +300,7 @@ describe('ArbitrumOrbitNativeBridgeProxy (deposit)', function () {
         // from IDelayedMessageProvider
         'event InboxMessageDelivered(uint256 indexed messageNum,bytes data)',
         // IBridge
-        'event MessageDelivered(uint256 indexed messageIndex,bytes32 indexed beforeInboxAcc,address inbox,uint8 kind,address sender,bytes32 messageDataHash,uint256 baseFeeL1,uint64 timestamp);',
+        'event MessageDelivered(uint256 indexed messageIndex,bytes32 indexed beforeInboxAcc,address inbox,uint8 kind,address sender,bytes32 messageDataHash,uint256 baseFeeL1,uint64 timestamp)',
       ])
 
       const inboxMessageDelivered = await getEvent(


### PR DESCRIPTION
The function mistakenly used `gasParams` to pass Arbitrum retryable ticket gas limit - which is reserved for `transaction.txParams` object. This PR fixes it