### PR TITLE
backend: avoid http server downtime by serving pg view

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ponder dev",
     "start": "ponder start --log-format json --log-level warn --views-schema=vaults-view --schema $IMAGE_TAG | sh $(pwd)/bin/log-format.sh",
-    "start-http-only": "ponder serve --log-level info --log-format json --schema $IMAGE_TAG | sh $(pwd)/bin/log-format.sh",
+    "start-http-only": "ponder serve --log-level info --log-format json --schema vaults-view | sh $(pwd)/bin/log-format.sh",
     "db": "ponder db",
     "codegen": "ponder codegen",
     "serve": "ponder serve",


### PR DESCRIPTION
the backend server relies on a stable db view to fetch data so we can be up even if the indexer is down